### PR TITLE
ci: fix version in filename for release

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://unpkg.com/release-it@17/schema/release-it.json",
     "hooks": {
-        "before:init": [
+        "after:bump": [
             "rm -f *.tgz",
-            "yarn pack --out '%s_%v.tgz'"
-        ],
-        "after:bump": "npx auto-changelog -p"
+            "yarn pack --out '%s_%v.tgz'",
+            "npx auto-changelog -p"
+        ]
     },
     "git": {
         "commitMessage": "chore: release ${version}",


### PR DESCRIPTION
In the previous releases the *.tgz was created before the version bump. So it had always the wrong version. This should be fixed with this PR.