### PR TITLE
ci: add icons to release notes

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -37,43 +37,43 @@
                 "types": [
                     {
                         "type": "feat",
-                        "section": "Features"
+                        "section": "🎉 Features"
                     },
                     {
                         "type": "fix",
-                        "section": "Bug Fixes"
+                        "section": "🐛 Bug Fixes"
                     },
                     {
                         "type": "perf",
-                        "section": "Performance Improvements"
+                        "section": "⚡️ Performance Improvements"
                     },
                     {
                         "type": "revert",
-                        "section": "Reverts"
+                        "section": "⏪️ Reverts"
                     },
                     {
                         "type": "docs",
-                        "section": "Documentation"
+                        "section": "📝 Documentation"
                     },
                     {
                         "type": "style",
-                        "section": "Styles"
+                        "section": "🎨 Styles"
                     },
                     {
                         "type": "refactor",
-                        "section": "Code Refactoring"
+                        "section": "🔀 Code Refactoring"
                     },
                     {
                         "type": "test",
-                        "section": "Tests"
+                        "section": "🧪 Tests"
                     },
                     {
                         "type": "build",
-                        "section": "Build System"
+                        "section": "⚙️ Build System"
                     },
                     {
                         "type": "ci",
-                        "section": "Continuous Integration"
+                        "section": "🚀 Continuous Integration"
                     }
                 ]
             },

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # EVVA React-Native Module
 
-[![NPM Version](https://img.shields.io/npm/v/%40evva-sfw%2Fabrevva-react-native)](https://www.npmjs.com/package/@evva/abrevva-react-native)
-[![NPM Downloads](https://img.shields.io/npm/dy/%40evva-sfw%2Fabrevva-react-native)](https://www.npmjs.com/package/@evva/abrevva-react-native)
+[![NPM Version](https://img.shields.io/npm/v/%40evva%2Fabrevva-react-native)](https://www.npmjs.com/package/@evva/abrevva-react-native)
+[![NPM Downloads](https://img.shields.io/npm/dy/%40evva%2Fabrevva-react-native)](https://www.npmjs.com/package/@evva/abrevva-react-native)
 ![GitHub package.json dynamic](https://img.shields.io/github/package-json/packageManager/evva-sfw/abrevva-react-native)
-![NPM Unpacked Size (with version)](https://img.shields.io/npm/unpacked-size/%40evva-sfw%2Fabrevva-react-native/latest)
+![NPM Unpacked Size (with version)](https://img.shields.io/npm/unpacked-size/%40evva%2Fabrevva-react-native/latest)
 ![GitHub last commit](https://img.shields.io/github/last-commit/evva-sfw/abrevva-react-native)
 [![GitHub branch check runs](https://img.shields.io/github/check-runs/evva-sfw/abrevva-react-native/main)]([URL](https://github.com/evva-sfw/abrevva-react-native/actions))
 [![EVVA License](https://img.shields.io/badge/license-EVVA_License-yellow.svg?color=fce500&logo=data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjY0MCIgaGVpZ2h0PSIxMDI0IiB2aWV3Qm94PSIwIDAgNjQwIDEwMjQiPgo8ZyBpZD0iaWNvbW9vbi1pZ25vcmUiPgo8L2c+CjxwYXRoIGZpbGw9IiNmY2U1MDAiIGQ9Ik02MjIuNDIzIDUxMS40NDhsLTMzMS43NDYtNDY0LjU1MmgtMjg4LjE1N2wzMjkuODI1IDQ2NC41NTItMzI5LjgyNSA0NjYuNjY0aDI3NS42MTJ6Ij48L3BhdGg+Cjwvc3ZnPgo=)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EVVA React-Native Module
+# Abrevva React-Native Module
 
 [![NPM Version](https://img.shields.io/npm/v/%40evva%2Fabrevva-react-native)](https://www.npmjs.com/package/@evva/abrevva-react-native)
 [![NPM Downloads](https://img.shields.io/npm/dy/%40evva%2Fabrevva-react-native)](https://www.npmjs.com/package/@evva/abrevva-react-native)


### PR DESCRIPTION
It is just a small change to unify the release notes with the icons.
And fixed some of the shields.io badges that were not changes with the rename of the package.