### PR TITLE
docs: set license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "type": "git",
     "url": "git+https://github.com/evva-sfw/abrevva-react-native.git"
   },
-  "license": "SEE LICENSE IN <LICENSE>",
+  "license": "EVVA Software License",
   "bugs": {
     "url": "https://github.com/evva-sfw/abrevva-react-native/issues"
   },


### PR DESCRIPTION
Set package.json license name to: EVVA Software License
Reason: we need a unique identifier to allow our license in license scans