### PR TITLE
ci: potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]


### PR DESCRIPTION
Potential fix for [https://github.com/evva-sfw/abrevva-react-native/security/code-scanning/6](https://github.com/evva-sfw/abrevva-react-native/security/code-scanning/6)

To fix the problem, add a top-level `permissions` block to the workflow file (`.github/workflows/test.yml`). This block should be set at the root of the workflow (before or after the `on:` key and above `jobs:`), which will apply the permissions to all jobs in the workflow unless overridden by a job-specific `permissions` key. Since all jobs shown (including `test-ios`) only require read access to repository contents for actions such as checkout and caching, the minimal permissions necessary are `contents: read`. You should add these lines directly beneath the `name:` or `on:` key in the workflow definition.

No additional imports, methods, or definitions are required. The entire change is a single addition to the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
