### PR TITLE
ci: ignore package.json version in releaseit step

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -18,6 +18,7 @@ module.exports = {
   npm: {
     publish: true,
     skipChecks: true,
+    ignoreVersion: true,
     publishArgs: [
       "--provenance"
     ]


### PR DESCRIPTION
ignoreVersion flag added to release-it.cjs as per release-it README, so package.json version is ignored

https://github.com/release-it/release-it/blob/main/docs/npm.md